### PR TITLE
fixed assignPlaced bug

### DIFF
--- a/src/main/java/assets/game.js
+++ b/src/main/java/assets/game.js
@@ -225,9 +225,21 @@ function assignPlaced(size, row, col){
 		}
 		let cell;
 		if(vertical){
-			if(table.rows[row+1] != undefined){cell = table.rows[row+1].cells[col];}
+			if(table.rows[row+1] != undefined){
+			    if(size === 4){
+			        cell = table.rows[row+2].cells[col];
+			    }
+			    else{
+			        cell = table.rows[row+1].cells[col];
+			    }
+			}
 		} else {
-		    cell = table.rows[row].cells[col+1];
+		    if(size === 4){
+		        cell = table.rows[row].cells[col+2];
+		    }
+		    else{
+		        cell = table.rows[row].cells[col+1];
+		    }
 		}
 		if(cell != undefined){cell.classList.toggle("cq");}
 }


### PR DESCRIPTION
Fixed the bug where assignPlaced wrongly assigned CQ on a Battleship ship on its 2nd square rather than its 3rd. Note assignedPlaced assigns class names to its squares when you hover your cursor over squares when placing ships.